### PR TITLE
Remove sequencer dependency and make own types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,8 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -3570,6 +3572,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "futures",
+ "num-bigint",
  "radius-sequencer-sdk",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ path = "src/bin/seeder.rs"
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
 futures = "0.3.30"
+num-bigint = { version = "0.4", features = ["rand", "serde"] }
 radius-sequencer-sdk = { git = "https://github.com/radiusxyz/radius-sdk-rs", rev="37b31eafb4d007ad9caff98ab2e64a4be556f1f4", features = ["full", "liveness-evm", "validation-eigenlayer"] }
 reqwest = { version = "0.12.4", features = ["json"] }
 serde = { version = "1.0.197", features = ["derive"] }
-sequencer = { git = "https://github.com/radiusxyz/sequencer", branch="feat/seeder" }
 tokio = { version = "1.37.0", features = ["full"] }
 toml = "0.8.13"
 tracing = "0.1.37"

--- a/src/bin/seeder.rs
+++ b/src/bin/seeder.rs
@@ -2,12 +2,10 @@ use radius_sequencer_sdk::{json_rpc::RpcServer, kvstore::KvStore as Database};
 use seeder::{
     cli::{Cli, Commands, Config, ConfigPath, DATABASE_DIR_NAME},
     error::Error,
-    rpc::*,
+    models::prelude::SequencingInfoModel,
+    rpc::methods::*,
+    sequencer_types::prelude::*,
     task::radius_liveness_event_listener,
-};
-use sequencer::{
-    models::SequencingInfoModel,
-    types::{PlatForm, ServiceType},
 };
 use tracing::info;
 
@@ -41,7 +39,7 @@ async fn main() -> Result<(), Error> {
                 }
             };
 
-            initialize_platform_listener(&sequencing_info_model);
+            initialize_event_listener(&sequencing_info_model);
 
             let rpc_server_handle = RpcServer::new(())
                 .register_rpc_method(AddSequencingInfo::METHOD_NAME, AddSequencingInfo::handler)?
@@ -66,7 +64,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-pub fn initialize_platform_listener(sequencing_info_model: &SequencingInfoModel) {
+pub fn initialize_event_listener(sequencing_info_model: &SequencingInfoModel) {
     sequencing_info_model.sequencing_infos().iter().for_each(
         |(sequencing_info_key, sequencing_info)| {
             info!(
@@ -82,7 +80,7 @@ pub fn initialize_platform_listener(sequencing_info_model: &SequencingInfoModel)
                     info!("Init local platform (TODO)");
                 }
                 PlatForm::Ethereum => match sequencing_info_key.sequencing_function_type() {
-                    sequencer::types::SequencingFunctionType::Liveness => {
+                    SequencingFunctionType::Liveness => {
                         match sequencing_info_key.service_type() {
                             ServiceType::Radius => {
                                 info!(
@@ -101,7 +99,7 @@ pub fn initialize_platform_listener(sequencing_info_model: &SequencingInfoModel)
                             }
                         }
                     }
-                    sequencer::types::SequencingFunctionType::Validation => {}
+                    SequencingFunctionType::Validation => {}
                 },
             }
         },

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -25,7 +25,7 @@ impl Config {
         // Read config file
         let config_file_path = config_path.join(CONFIG_FILE_NAME);
         let config_string =
-            fs::read_to_string(&config_file_path).map_err(|_| Error::LoadConfigOption)?;
+            fs::read_to_string(config_file_path).map_err(|_| Error::LoadConfigOption)?;
 
         // Parse String to TOML String
         let config_file: ConfigOption =

--- a/src/cli/config_option.rs
+++ b/src/cli/config_option.rs
@@ -39,11 +39,11 @@ impl ConfigOption {
 
     pub fn merge(mut self, other: &ConfigOption) -> Self {
         if other.path.is_some() {
-            self.path = other.path.clone();
+            self.path.clone_from(&other.path)
         }
 
         if other.seeder_rpc_url.is_some() {
-            self.seeder_rpc_url = other.seeder_rpc_url.clone();
+            self.seeder_rpc_url.clone_from(&other.seeder_rpc_url)
         }
 
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cli;
 pub mod error;
 pub mod models;
 pub mod rpc;
+pub mod sequencer_types;
 pub mod task;
 pub mod util;

--- a/src/models/cluster/cluster_id_list.rs
+++ b/src/models/cluster/cluster_id_list.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{models::prelude::*, sequencer_types::prelude::*};
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub struct ClusterIdListModel {
+    cluster_id_list: ClusterIdList,
+}
+
+impl ClusterIdListModel {
+    pub fn new(cluster_id_list: ClusterIdList) -> Self {
+        Self { cluster_id_list }
+    }
+
+    pub fn cluster_id_list(self) -> ClusterIdList {
+        self.cluster_id_list
+    }
+
+    pub fn add_cluster_id(&mut self, cluster_id: ClusterId) {
+        let is_exist_cluster_id = self.cluster_id_list.contains(&cluster_id);
+
+        if !is_exist_cluster_id {
+            self.cluster_id_list.push(cluster_id);
+        }
+    }
+
+    pub fn is_added_cluster_id(&self, cluster_id: &ClusterId) -> bool {
+        self.cluster_id_list.contains(cluster_id)
+    }
+}
+
+impl ClusterIdListModel {
+    pub const ID: &'static str = stringify!(ClusterIdListModel);
+
+    pub fn get(
+        platform: &PlatForm,
+        sequencing_function_type: &SequencingFunctionType,
+        service_type: &ServiceType,
+    ) -> Result<Self, DbError> {
+        let key = (Self::ID, platform, sequencing_function_type, service_type);
+        database()?.get(&key)
+    }
+
+    pub fn get_mut(
+        platform: &PlatForm,
+        sequencing_function_type: &SequencingFunctionType,
+        service_type: &ServiceType,
+    ) -> Result<Lock<'static, Self>, DbError> {
+        let key = (Self::ID, platform, sequencing_function_type, service_type);
+        database()?.get_mut(&key)
+    }
+
+    pub fn put(
+        &self,
+        platform: &PlatForm,
+        sequencing_function_type: &SequencingFunctionType,
+        service_type: &ServiceType,
+    ) -> Result<(), DbError> {
+        let key = (
+            Self::ID,
+            &platform,
+            &sequencing_function_type,
+            &service_type,
+        );
+        database()?.put(&key, self)
+    }
+}

--- a/src/models/cluster/liveness_cluster.rs
+++ b/src/models/cluster/liveness_cluster.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{models::prelude::*, sequencer_types::prelude::*};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LivenessClusterModel {
+    pub platform: PlatForm,
+    pub service_type: ServiceType,
+
+    pub cluster_id: ClusterId,
+
+    // TODO: change this property to RpcClients
+    pub sequencer_address_list: AddressList,
+}
+
+impl LivenessClusterModel {
+    pub fn new(platform: PlatForm, service_type: ServiceType, cluster_id: ClusterId) -> Self {
+        Self {
+            platform,
+            cluster_id,
+            service_type,
+
+            sequencer_address_list: AddressList::new(),
+        }
+    }
+
+    pub fn set_sequencer_list(&mut self, sequencer_addresses: AddressList) {
+        self.sequencer_address_list = sequencer_addresses;
+    }
+
+    pub fn add_seqeuncer(&mut self, sequencer_address: Address) {
+        let is_exist_sequencer_address = self.sequencer_address_list.contains(&sequencer_address);
+
+        if !is_exist_sequencer_address {
+            self.sequencer_address_list.push(sequencer_address);
+        }
+    }
+
+    pub fn remove_sequencer(&mut self, sequencer_address: &Address) {
+        let sequencer_address_list = self
+            .sequencer_address_list
+            .iter()
+            .filter(|&address| address != sequencer_address)
+            .cloned()
+            .collect();
+
+        self.set_sequencer_list(sequencer_address_list);
+    }
+}
+
+impl LivenessClusterModel {
+    pub const ID: &'static str = stringify!(LivenessClusterModel);
+
+    pub fn get(
+        platform: &PlatForm,
+        service_type: &ServiceType,
+
+        cluster_id: &ClusterId,
+    ) -> Result<Self, DbError> {
+        let key = (Self::ID, platform, service_type, cluster_id);
+        database()?.get(&key)
+    }
+
+    pub fn get_mut(
+        platform: &PlatForm,
+        service_type: &ServiceType,
+
+        cluster_id: &ClusterId,
+    ) -> Result<Lock<'static, Self>, DbError> {
+        let key = (Self::ID, platform, service_type, cluster_id);
+        database()?.get_mut(&key)
+    }
+
+    pub fn put(&self) -> Result<(), DbError> {
+        let key = (
+            Self::ID,
+            &self.platform,
+            &self.service_type,
+            &self.cluster_id,
+        );
+        database()?.put(&key, self)
+    }
+}

--- a/src/models/cluster/mod.rs
+++ b/src/models/cluster/mod.rs
@@ -1,0 +1,15 @@
+mod cluster_id_list;
+mod liveness_cluster;
+mod validation_cluster;
+
+pub use cluster_id_list::*;
+pub use liveness_cluster::*;
+use serde::{Deserialize, Serialize};
+pub use validation_cluster::*;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClusterModel {
+    Liveness(LivenessClusterModel),
+    Validation(ValidationClusterModel),
+}

--- a/src/models/cluster/validation_cluster.rs
+++ b/src/models/cluster/validation_cluster.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{models::prelude::*, sequencer_types::prelude::*};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ValidationClusterModel {
+    pub platform: PlatForm,
+    pub service_type: ServiceType,
+
+    pub cluster_id: ClusterId,
+    pub validator_address_list: AddressList,
+}
+
+impl ValidationClusterModel {
+    pub fn new(platform: PlatForm, service_type: ServiceType, cluster_id: ClusterId) -> Self {
+        Self {
+            platform,
+            service_type,
+
+            cluster_id,
+            validator_address_list: AddressList::new(),
+        }
+    }
+
+    pub fn set_validator_list(&mut self, validator_addresses: AddressList) {
+        self.validator_address_list = validator_addresses;
+    }
+
+    pub fn add_seqeuncer(&mut self, validator_address: Address) {
+        let is_exist_validator_address = self.validator_address_list.contains(&validator_address);
+
+        if !is_exist_validator_address {
+            self.validator_address_list.push(validator_address);
+        }
+    }
+
+    pub fn remove_validator(&mut self, validator_address: &Address) {
+        let validator_address_list = self
+            .validator_address_list
+            .iter()
+            .filter(|&address| address != validator_address)
+            .cloned()
+            .collect();
+
+        self.set_validator_list(validator_address_list);
+    }
+}
+
+impl ValidationClusterModel {
+    pub const ID: &'static str = stringify!(ValidationClusterModel);
+
+    pub fn get(
+        platform: &PlatForm,
+        service_type: &ServiceType,
+
+        cluster_id: &ClusterId,
+    ) -> Result<Self, DbError> {
+        let key = (Self::ID, platform, service_type, cluster_id);
+        database()?.get(&key)
+    }
+
+    pub fn get_mut(
+        platform: &PlatForm,
+        service_type: &ServiceType,
+
+        cluster_id: &ClusterId,
+    ) -> Result<Lock<'static, Self>, DbError> {
+        let key = (Self::ID, platform, service_type, cluster_id);
+        database()?.get_mut(&key)
+    }
+
+    pub fn put(&self) -> Result<(), DbError> {
+        let key = (
+            Self::ID,
+            &self.platform,
+            &self.service_type,
+            &self.cluster_id,
+        );
+        database()?.put(&key, self)
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,11 +1,9 @@
+mod cluster;
 mod operator;
-
-pub use operator::*;
+mod sequencing;
 
 pub mod prelude {
-    pub use std::sync::Arc;
-
     pub use radius_sequencer_sdk::kvstore::{kvstore as database, KvStoreError as DbError, Lock};
-    pub use sequencer::types::*;
-    pub use serde::{Deserialize, Serialize};
+
+    pub use crate::models::{cluster::*, operator::*, sequencing::*};
 }

--- a/src/models/operator.rs
+++ b/src/models/operator.rs
@@ -1,4 +1,9 @@
-use crate::models::prelude::*;
+pub use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::prelude::*,
+    sequencer_types::prelude::{Address, IpAddress},
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OperatorModel {

--- a/src/models/sequencing.rs
+++ b/src/models/sequencing.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+
+use crate::{models::prelude::*, sequencer_types::prelude::*};
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct SequencingInfoModel {
+    // Todo: change
+    sequencing_infos: HashMap<SequencingInfoKey, SequencingInfo>,
+}
+
+impl SequencingInfoModel {
+    pub fn new(sequencing_infos: HashMap<SequencingInfoKey, SequencingInfo>) -> Self {
+        Self { sequencing_infos }
+    }
+
+    pub fn sequencing_infos(&self) -> &HashMap<SequencingInfoKey, SequencingInfo> {
+        &self.sequencing_infos
+    }
+
+    pub fn sequencing_infos_mut(&mut self) -> &mut HashMap<SequencingInfoKey, SequencingInfo> {
+        &mut self.sequencing_infos
+    }
+}
+
+impl SequencingInfoModel {
+    pub fn add(sequencing_info: SequencingInfo) -> Result<(), DbError> {
+        match Self::get_mut() {
+            Ok(mut sequencing_info_model) => {
+                sequencing_info_model.sequencing_infos_mut().insert(
+                    SequencingInfoKey::new(
+                        sequencing_info.platform.clone(),
+                        sequencing_info.sequencing_function_type.clone(),
+                        sequencing_info.service_type.clone(),
+                    ),
+                    sequencing_info,
+                );
+
+                sequencing_info_model.update()?;
+            }
+            Err(_) => {
+                let mut sequencing_info_model = Self::new(HashMap::new());
+                sequencing_info_model.sequencing_infos_mut().insert(
+                    SequencingInfoKey::new(
+                        sequencing_info.platform.clone(),
+                        sequencing_info.sequencing_function_type.clone(),
+                        sequencing_info.service_type.clone(),
+                    ),
+                    sequencing_info,
+                );
+                sequencing_info_model.put()?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SequencingInfoModel {
+    pub const ID: &'static str = stringify!(SequencingInfoModel);
+
+    pub fn get() -> Result<Self, DbError> {
+        let key = Self::ID;
+        database()?.get(&key)
+    }
+
+    pub fn get_mut() -> Result<Lock<'static, Self>, DbError> {
+        let key = Self::ID;
+        database()?.get_mut(&key)
+    }
+
+    pub fn put(&self) -> Result<(), DbError> {
+        let key = Self::ID;
+        database()?.put(&key, self)
+    }
+}

--- a/src/rpc/cluster/deregister.rs
+++ b/src/rpc/cluster/deregister.rs
@@ -1,9 +1,12 @@
-use sequencer::{
-    models::{LivenessClusterModel, ValidationClusterModel},
-    types::{Address, ClusterId, PlatForm, SequencingFunctionType, ServiceType},
-};
+use std::sync::Arc;
 
-use crate::rpc::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::prelude::{LivenessClusterModel, ValidationClusterModel},
+    rpc::prelude::*,
+    sequencer_types::prelude::*,
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Deregister {

--- a/src/rpc/cluster/get_cluster.rs
+++ b/src/rpc/cluster/get_cluster.rs
@@ -1,9 +1,6 @@
-use sequencer::{
-    models::{ClusterModel, LivenessClusterModel, ValidationClusterModel},
-    types::{ClusterId, PlatForm, SequencingFunctionType, ServiceType},
-};
+use std::sync::Arc;
 
-use crate::rpc::prelude::*;
+use crate::{models::prelude::*, rpc::prelude::*, sequencer_types::prelude::*};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GetCluster {

--- a/src/rpc/cluster/get_cluster_list.rs
+++ b/src/rpc/cluster/get_cluster_list.rs
@@ -1,10 +1,6 @@
-use radius_sequencer_sdk::kvstore::KvStoreError;
-use sequencer::{
-    models::{ClusterIdListModel, ClusterModel, LivenessClusterModel, ValidationClusterModel},
-    types::{PlatForm, SequencingFunctionType, ServiceType},
-};
+use std::sync::Arc;
 
-use crate::rpc::prelude::*;
+use crate::{models::prelude::*, rpc::prelude::*, sequencer_types::prelude::*};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GetClusterList {
@@ -54,7 +50,7 @@ impl GetClusterList {
                     }
                 })
             })
-            .collect::<Result<Vec<ClusterModel>, KvStoreError>>()?;
+            .collect::<Result<Vec<ClusterModel>, DbError>>()?;
 
         Ok(GetClusterListResponse { cluster_list })
     }

--- a/src/rpc/cluster/get_rpc_url.rs
+++ b/src/rpc/cluster/get_rpc_url.rs
@@ -1,7 +1,13 @@
-use sequencer::types::{Address, IpAddress};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::{models::OperatorModel, rpc::prelude::*};
+use crate::{
+    models::prelude::OperatorModel,
+    rpc::prelude::*,
+    sequencer_types::prelude::{Address, IpAddress},
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GetRpcUrl {

--- a/src/rpc/cluster/get_rpc_url_list.rs
+++ b/src/rpc/cluster/get_rpc_url_list.rs
@@ -1,10 +1,8 @@
-use sequencer::{
-    models::{LivenessClusterModel, ValidationClusterModel},
-    types::{Address, ClusterId, IpAddress, PlatForm, SequencingFunctionType, ServiceType},
-};
+use std::sync::Arc;
+
 use tracing::info;
 
-use crate::{models::OperatorModel, rpc::prelude::*};
+use crate::{models::prelude::*, rpc::prelude::*, sequencer_types::prelude::*};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GetRpcUrlList {

--- a/src/rpc/cluster/initialize_cluster.rs
+++ b/src/rpc/cluster/initialize_cluster.rs
@@ -1,9 +1,8 @@
-use sequencer::{
-    models::{ClusterIdListModel, LivenessClusterModel, ValidationClusterModel},
-    types::{ClusterId, PlatForm, SequencingFunctionType, ServiceType},
-};
+use std::sync::Arc;
 
-use crate::rpc::prelude::*;
+use prelude::*;
+
+use crate::{models::prelude::*, rpc::prelude::*, sequencer_types::*};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InitializeCluster {

--- a/src/rpc/cluster/register.rs
+++ b/src/rpc/cluster/register.rs
@@ -1,9 +1,12 @@
-use sequencer::{
-    models::{LivenessClusterModel, ValidationClusterModel},
-    types::{Address, ClusterId, PlatForm, SequencingFunctionType, ServiceType},
-};
+use std::sync::Arc;
 
-use crate::rpc::prelude::*;
+use radius_sequencer_sdk::json_rpc::{types::RpcParameter, RpcError};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::prelude::{LivenessClusterModel, ValidationClusterModel},
+    sequencer_types::prelude::*,
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Register {

--- a/src/rpc/cluster/register_rpc_url.rs
+++ b/src/rpc/cluster/register_rpc_url.rs
@@ -1,6 +1,12 @@
-use sequencer::types::{Address, IpAddress};
+use std::sync::Arc;
 
-use crate::{models::OperatorModel, rpc::prelude::*};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::prelude::OperatorModel,
+    rpc::prelude::{RpcError, RpcParameter},
+    sequencer_types::prelude::{Address, IpAddress},
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RegisterRpcUrl {
@@ -30,15 +36,13 @@ impl RegisterRpcUrl {
             Ok(sequencer) => {
                 tracing::warn!("Already registered sequencer: {:?}", sequencer);
 
-                let sequencer =
-                    OperatorModel::new(parameter.address.into(), parameter.rpc_url.into());
+                let sequencer = OperatorModel::new(parameter.address, parameter.rpc_url.into());
 
                 sequencer.put()?;
             }
             Err(err) => {
                 if err.is_none_type() {
-                    let sequencer =
-                        OperatorModel::new(parameter.address.into(), parameter.rpc_url.into());
+                    let sequencer = OperatorModel::new(parameter.address, parameter.rpc_url.into());
 
                     sequencer.put()?;
                 } else {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,12 +1,10 @@
 mod cluster;
 mod sequencing;
 
-pub use cluster::*;
-pub use sequencing::*;
-
 mod prelude {
-    pub use std::sync::Arc;
-
     pub use radius_sequencer_sdk::json_rpc::{types::*, RpcError};
-    pub use serde::{Deserialize, Serialize};
+}
+
+pub mod methods {
+    pub use crate::rpc::{cluster::*, sequencing::*};
 }

--- a/src/rpc/sequencing/add_sequencing_info.rs
+++ b/src/rpc/sequencing/add_sequencing_info.rs
@@ -1,9 +1,12 @@
-use sequencer::{
-    models::SequencingInfoModel,
-    types::{Address, IpAddress, PlatForm, SequencingFunctionType, SequencingInfo, ServiceType},
-};
+use std::sync::Arc;
 
-use crate::{rpc::prelude::*, task::radius_liveness_event_listener};
+use prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::prelude::SequencingInfoModel, rpc::prelude::*, sequencer_types::*,
+    task::radius_liveness_event_listener,
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AddSequencingInfo {
@@ -40,19 +43,12 @@ impl AddSequencingInfo {
             parameter.contract_address,
         );
 
-        // TODO
-        if parameter.platform != PlatForm::Local {
-            if parameter.sequencing_function_type == SequencingFunctionType::Liveness {
-                match parameter.service_type {
-                    ServiceType::Radius => {
-                        radius_liveness_event_listener::init(sequencing_info.clone());
-                    }
-                    _ => {}
-                }
-            }
-
-            // TODO
-            if parameter.sequencing_function_type == SequencingFunctionType::Validation {}
+        // TODO: Add process logic other branch
+        if parameter.platform != PlatForm::Local
+            && parameter.sequencing_function_type == SequencingFunctionType::Liveness
+            && parameter.service_type == ServiceType::Radius
+        {
+            radius_liveness_event_listener::init(sequencing_info.clone());
         }
 
         SequencingInfoModel::add(sequencing_info)?;

--- a/src/rpc/sequencing/get_sequencing_info.rs
+++ b/src/rpc/sequencing/get_sequencing_info.rs
@@ -1,9 +1,13 @@
-use sequencer::{
-    models::SequencingInfoModel,
-    types::{SequencingInfo, SequencingInfoKey},
-};
+use std::sync::Arc;
 
-use crate::{error::Error, rpc::prelude::*};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::Error,
+    models::prelude::SequencingInfoModel,
+    rpc::prelude::*,
+    sequencer_types::prelude::{SequencingInfo, SequencingInfoKey},
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GetSequencingInfo {

--- a/src/rpc/sequencing/get_sequencing_infos.rs
+++ b/src/rpc/sequencing/get_sequencing_infos.rs
@@ -1,8 +1,9 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
-use sequencer::{models::SequencingInfoModel, types::SequencingInfo};
+use radius_sequencer_sdk::json_rpc::{types::RpcParameter, RpcError};
+pub use serde::{Deserialize, Serialize};
 
-use crate::rpc::prelude::*;
+use crate::{models::prelude::SequencingInfoModel, sequencer_types::prelude::SequencingInfo};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GetSequencingInfos {}

--- a/src/sequencer_types/block.rs
+++ b/src/sequencer_types/block.rs
@@ -1,0 +1,69 @@
+pub type BlockHeight = u64;
+
+// #[derive(Clone, Debug, Deserialize, Serialize)]
+// pub struct Timestamp(String);
+
+// impl Timestamp {
+//     pub fn new(value: impl AsRef<str>) -> Self {
+//         Self(value.as_ref().to_owned())
+//     }
+
+//     pub fn into_inner(self) -> String {
+//         self.0
+//     }
+// }
+
+// #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+// pub struct BlockCommitment(Vec<u8>);
+
+// impl AsRef<[u8]> for BlockCommitment {
+//     fn as_ref(&self) -> &[u8] {
+//         &self.0
+//     }
+// }
+
+// impl From<Vec<u8>> for BlockCommitment {
+//     fn from(value: Vec<u8>) -> Self {
+//         Self(value)
+//     }
+// }
+
+// #[derive(Clone, Debug, Deserialize, Serialize)]
+// pub struct Block {
+//     block_height: BlockHeight,
+
+//     encrypted_transaction_list: EncryptedTransactionList,
+//     raw_transaction_list: RawTransactionList,
+
+//     proposer_address: Address,
+//     signature: Signature,
+//     timestamp: Timestamp,
+
+//     block_commitment: BlockCommitment,
+// }
+
+// impl Block {
+//     pub fn new(
+//         block_height: BlockHeight,
+//         encrypted_transaction_list: EncryptedTransactionList,
+//         raw_transaction_list: RawTransactionList,
+//         proposer_address: Address,
+//         signature: Signature,
+//         timestamp: Timestamp,
+//         block_commitment: BlockCommitment,
+//     ) -> Self {
+//         Self {
+//             block_height,
+//             encrypted_transaction_list,
+//             raw_transaction_list,
+//             proposer_address,
+//             signature,
+//             timestamp,
+//             block_commitment,
+//         }
+//     }
+
+//     pub fn block_height(&self) -> &BlockHeight {
+//         &self.block_height
+//     }
+// }

--- a/src/sequencer_types/cluster.rs
+++ b/src/sequencer_types/cluster.rs
@@ -1,0 +1,205 @@
+use std::{collections::HashMap, sync::Arc};
+
+use num_bigint::BigUint;
+use radius_sequencer_sdk::{context::SharedContext, json_rpc::RpcClient};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::sequencer_types::prelude::*;
+
+pub type SequencerIndex = usize;
+pub type ClusterId = String;
+pub type ClusterIdList = Vec<ClusterId>;
+
+pub struct SequencerClient(Arc<RpcClient>);
+
+unsafe impl Send for SequencerClient {}
+
+unsafe impl Sync for SequencerClient {}
+
+impl Clone for SequencerClient {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PartialKey {
+    pub u: BigUint,
+    pub v: BigUint,
+    pub y: BigUint,
+    pub w: BigUint,
+}
+
+pub struct Cluster {
+    inner: Arc<ClusterInner>,
+}
+
+struct ClusterInner {
+    cluster_id: ClusterId,
+    node_address: Address,
+    sequencer_rpc_client_list: SharedContext<Vec<(Address, SequencerClient)>>,
+
+    partial_keys: Mutex<HashMap<Address, PartialKey>>,
+}
+
+unsafe impl Send for Cluster {}
+
+unsafe impl Sync for Cluster {}
+
+impl Clone for Cluster {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl Cluster {
+    pub fn new(cluster_id: ClusterId, node_address: Address) -> Self {
+        let inner = ClusterInner {
+            cluster_id,
+            node_address,
+            sequencer_rpc_client_list: SharedContext::from(Vec::new()),
+            partial_keys: Mutex::new(HashMap::new()),
+        };
+
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    pub fn node_address(&self) -> &Address {
+        &self.inner.node_address
+    }
+
+    pub async fn add_partial_key(&self, address: Address, partial_key: PartialKey) {
+        let mut partial_keys_lock = self.inner.partial_keys.lock().await;
+        partial_keys_lock.insert(address, partial_key);
+    }
+
+    pub async fn get_partial_key_list(&self) -> Vec<PartialKey> {
+        // TODO
+        let partial_keys_lock = self.inner.partial_keys.lock().await.clone();
+        println!("stompesi - partial_keys_lock: {:?}", partial_keys_lock);
+
+        let sorted_partial_key_list: Vec<PartialKey> = self
+            .inner
+            .sequencer_rpc_client_list
+            .load()
+            .as_ref()
+            .iter()
+            .filter_map(|(address, _)| partial_keys_lock.get(address).cloned())
+            .collect();
+
+        sorted_partial_key_list
+    }
+
+    pub async fn add_sequencer_rpc_client(
+        &self,
+        address: Address,
+        sequencer_client: SequencerClient,
+    ) {
+        let mut sequencer_rpc_clients =
+            self.inner.sequencer_rpc_client_list.load().as_ref().clone();
+        sequencer_rpc_clients.push((address.clone(), sequencer_client));
+
+        self.inner
+            .sequencer_rpc_client_list
+            .store(sequencer_rpc_clients);
+    }
+
+    // Todo: after remove, sort sequencer index
+    pub fn remove_sequencer_rpc_client(&self, address: Address) {
+        let mut sequencer_rpc_client_list =
+            self.inner.sequencer_rpc_client_list.load().as_ref().clone();
+
+        sequencer_rpc_client_list.retain(|(rpc_address, _)| rpc_address != &address);
+
+        self.inner
+            .sequencer_rpc_client_list
+            .store(sequencer_rpc_client_list);
+    }
+
+    pub fn set_sequencer_rpc_client_list(
+        &mut self,
+        sequencer_rpc_clients: Vec<(Address, SequencerClient)>,
+    ) {
+        self.inner
+            .sequencer_rpc_client_list
+            .store(sequencer_rpc_clients)
+    }
+
+    pub fn cluster_id(&self) -> &ClusterId {
+        &self.inner.cluster_id
+    }
+
+    pub async fn get_other_sequencer_rpc_clients(&self) -> Vec<SequencerClient> {
+        self.inner
+            .sequencer_rpc_client_list
+            .load()
+            .as_ref()
+            .iter()
+            .filter(|&(address, _)| (address != &self.inner.node_address))
+            .map(|(_, rpc_client)| rpc_client.clone())
+            .collect()
+    }
+
+    pub async fn sequencer_rpc_clients(&self) -> Vec<SequencerClient> {
+        self.inner
+            .sequencer_rpc_client_list
+            .load()
+            .as_ref()
+            .iter()
+            .map(|(_, rpc_client)| rpc_client.clone())
+            .collect()
+    }
+
+    pub async fn is_leader(&self, rollup_block_height: BlockHeight) -> bool {
+        let sequencer_rpc_client_list_context = self.inner.sequencer_rpc_client_list.load();
+
+        let sequencer_rpc_client_list = sequencer_rpc_client_list_context.as_ref();
+        let leader_index = (rollup_block_height % sequencer_rpc_client_list.len() as BlockHeight)
+            as SequencerIndex;
+
+        sequencer_rpc_client_list
+            .get(leader_index)
+            .map(|(address, _)| address == self.node_address())
+            .unwrap_or(false)
+    }
+
+    pub async fn get_leader_rpc_client(&self, rollup_block_height: BlockHeight) -> SequencerClient {
+        let sequencer_rpc_client_list_context = self.inner.sequencer_rpc_client_list.load();
+
+        let sequencer_rpc_client_list = sequencer_rpc_client_list_context.as_ref();
+        let leader_index = (rollup_block_height % sequencer_rpc_client_list.len() as BlockHeight)
+            as SequencerIndex;
+
+        println!("jaemin - leader_index: {:?}", leader_index);
+
+        let leader = sequencer_rpc_client_list.get(leader_index).unwrap();
+        println!("jaemin - leader_address: {:?}", leader.0);
+
+        leader.1.clone()
+    }
+
+    pub async fn get_follower_rpc_client_list(
+        &self,
+        rollup_block_height: BlockHeight,
+    ) -> Vec<SequencerClient> {
+        let sequencer_rpc_client_list_context = self.inner.sequencer_rpc_client_list.load();
+
+        let sequencer_rpc_client_list = sequencer_rpc_client_list_context.as_ref();
+        let leader_index = (rollup_block_height % sequencer_rpc_client_list.len() as BlockHeight)
+            as SequencerIndex;
+
+        sequencer_rpc_client_list
+            .iter()
+            .enumerate()
+            .filter(|&(sequencer_index, (address, _))| {
+                address != self.node_address() && sequencer_index != leader_index
+            })
+            .map(|(_, (_, rpc_client))| rpc_client.clone())
+            .collect()
+    }
+}

--- a/src/sequencer_types/mod.rs
+++ b/src/sequencer_types/mod.rs
@@ -1,0 +1,11 @@
+mod block;
+mod cluster;
+mod sequencer;
+mod sequencing;
+mod signer;
+
+pub mod prelude {
+    pub use crate::sequencer_types::{
+        block::*, cluster::*, sequencer::*, sequencing::*, signer::*,
+    };
+}

--- a/src/sequencer_types/sequencer.rs
+++ b/src/sequencer_types/sequencer.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+pub type IpAddress = String;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum SequencerStatus {
+    Uninitialized,
+    Running,
+}
+
+// #[derive(Clone, Debug, Deserialize, Serialize)]
+// pub struct SequencerList(Vec<(Address, Option<String>)>);
+
+// impl From<(Vec<Address>, Vec<Option<String>>)> for SequencerList {
+//     fn from(value: (Vec<Address>, Vec<Option<String>>)) -> Self {
+//         Self(std::iter::zip(value.0, value.1).collect())
+//     }
+// }
+
+// impl From<Vec<(Address, Option<String>)>> for SequencerList {
+//     fn from(value: Vec<(Address, Option<String>)>) -> Self {
+//         Self(value)
+//     }
+// }

--- a/src/sequencer_types/sequencing.rs
+++ b/src/sequencer_types/sequencing.rs
@@ -1,0 +1,128 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::sequencer_types::prelude::{Address, IpAddress};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PlatForm {
+    Local,
+    Ethereum,
+}
+
+impl Display for PlatForm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PlatForm::Local => write!(f, "local"),
+            PlatForm::Ethereum => write!(f, "ethereum"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum SequencingFunctionType {
+    Liveness,
+    Validation,
+}
+
+impl Display for SequencingFunctionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SequencingFunctionType::Liveness => write!(f, "liveness"),
+            SequencingFunctionType::Validation => write!(f, "validation"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceType {
+    Local,
+    Radius,
+}
+
+impl Display for ServiceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServiceType::Local => write!(f, "local"),
+            ServiceType::Radius => write!(f, "radius"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SequencingInfo {
+    pub platform: PlatForm,
+    pub sequencing_function_type: SequencingFunctionType,
+    pub service_type: ServiceType,
+
+    pub provider_rpc_url: IpAddress,
+    pub provider_websocket_url: IpAddress,
+
+    pub contract_address: Option<Address>,
+}
+
+impl SequencingInfo {
+    pub fn new(
+        platform: PlatForm,
+        sequencing_function_type: SequencingFunctionType,
+        service_type: ServiceType,
+        provider_rpc_url: IpAddress,
+        provider_websocket_url: IpAddress,
+        contract_address: Option<Address>,
+    ) -> Self {
+        Self {
+            platform,
+            sequencing_function_type,
+            service_type,
+            provider_rpc_url,
+            provider_websocket_url,
+            contract_address,
+        }
+    }
+
+    pub fn platform(&self) -> &PlatForm {
+        &self.platform
+    }
+
+    pub fn sequencing_function_type(&self) -> &SequencingFunctionType {
+        &self.sequencing_function_type
+    }
+
+    pub fn service_type(&self) -> &ServiceType {
+        &self.service_type
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SequencingInfoKey(PlatForm, SequencingFunctionType, ServiceType);
+
+impl SequencingInfoKey {
+    pub fn new(
+        platform: PlatForm,
+        sequencing_function_type: SequencingFunctionType,
+        service_type: ServiceType,
+    ) -> Self {
+        Self(platform, sequencing_function_type, service_type)
+    }
+
+    pub fn platform(&self) -> &PlatForm {
+        &self.0
+    }
+
+    pub fn sequencing_function_type(&self) -> &SequencingFunctionType {
+        &self.1
+    }
+
+    pub fn service_type(&self) -> &ServiceType {
+        &self.2
+    }
+}
+
+impl Display for SequencingInfoKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}-{}", self.0, self.1, self.2)
+    }
+}

--- a/src/sequencer_types/signer.rs
+++ b/src/sequencer_types/signer.rs
@@ -1,0 +1,110 @@
+use std::fmt::Display;
+
+use radius_sequencer_sdk::liveness::types::Address as AlloyAddress;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SigningKey(String);
+
+impl SigningKey {
+    pub fn new(value: impl AsRef<str>) -> Self {
+        Self(value.as_ref().to_owned())
+    }
+
+    // TODO: change
+    pub fn get_address(&self) -> Address {
+        if self.0 == "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" {
+            return Address::new("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        } else if self.0 == "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff81" {
+            return Address::new("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92267");
+        } else if self.0 == "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff82" {
+            return Address::new("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92268");
+        } else if self.0 == "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff83" {
+            return Address::new("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92269");
+        } else if self.0 == "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff84" {
+            return Address::new("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92270");
+        }
+
+        Address::new("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92271")
+    }
+}
+
+impl From<String> for SigningKey {
+    fn from(signing_key: String) -> Self {
+        Self(signing_key)
+    }
+}
+
+impl From<&str> for SigningKey {
+    fn from(signing_key: &str) -> Self {
+        Self(signing_key.to_owned())
+    }
+}
+
+impl From<SigningKey> for String {
+    fn from(signing_key: SigningKey) -> String {
+        signing_key.0
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PublicKey(String);
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Default)]
+pub struct Address(String);
+
+impl Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Address {
+    pub fn new(value: impl AsRef<str>) -> Self {
+        Self(value.as_ref().to_owned())
+    }
+}
+
+impl From<String> for Address {
+    fn from(address: String) -> Self {
+        Self(address)
+    }
+}
+
+impl From<&str> for Address {
+    fn from(address: &str) -> Self {
+        Self(address.to_owned())
+    }
+}
+
+// TODO:
+impl PartialEq<AlloyAddress> for Address {
+    fn eq(&self, other: &AlloyAddress) -> bool {
+        self.0 == other.to_string()
+    }
+}
+
+pub type AddressList = Vec<Address>;
+
+impl PartialEq<Address> for AlloyAddress {
+    fn eq(&self, other: &Address) -> bool {
+        other == self // AddressString에 대한 PartialEq 구현을 사용합니다.
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Signature {
+    r: String,
+    s: String,
+    v: String,
+}
+
+impl Default for Signature {
+    fn default() -> Self {
+        Self {
+            r: "".to_string(),
+            s: "".to_string(),
+            v: "".to_string(),
+        }
+    }
+}

--- a/src/task/radius_liveness_event_listener.rs
+++ b/src/task/radius_liveness_event_listener.rs
@@ -4,14 +4,10 @@ use radius_sequencer_sdk::liveness::{
     subscriber::Subscriber,
     types::{Events, Ssal::SsalEvents},
 };
-use sequencer::{
-    models::{ClusterIdListModel, LivenessClusterModel},
-    types::{Address, ClusterId, PlatForm, SequencingFunctionType, SequencingInfo, ServiceType},
-};
 use tokio::time::sleep;
 use tracing::info;
 
-use crate::error::Error;
+use crate::{error::Error, models::prelude::*, sequencer_types::prelude::*};
 
 pub fn init(sequencing_info: SequencingInfo) {
     tokio::spawn(async move {


### PR DESCRIPTION
Removed the sequencer dependency by creating types in the seeder that depend on the sequencer, and functionalities are maintained.